### PR TITLE
Run fpm pool as the host's user by creating a `sq1` user under the same id

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,13 @@ Image Name: `moderntribe/squareone-php`
   the first release of a build for PHP 8.0.
 * Tags should follow semantic versioning: `php<version>-<major>.<minor>.<patch>`. `<major>` versions introduce
   breaking changes. `<minor>` versions add features and fix bugs. `<patch>` versions fix bugs.
+  
+### Downstream entrypoint scripts
+
+When using a Dockerfile from this repo in the downstream, you can add custom scripts in the `docker-entrypoint.d` folder.
+
+All scripts in there will be copied over and automatically executed with 
+[run-parts](https://manpages.ubuntu.com/manpages/trusty/man8/run-parts.8.html)
+
+Keep in mind the limitations of naming these scripts, they must consist entirely of ASCII upper- and lower-case letters, 
+ASCII digits, ASCII underscores, and ASCII minus-hyphens. So no .sh extensions.

--- a/php/7.4/Dockerfile
+++ b/php/7.4/Dockerfile
@@ -3,6 +3,18 @@ FROM phpdockerio/php74-fpm:latest
 # Fix debconf warnings upon build
 ARG DEBIAN_FRONTEND=noninteractive
 
+# Passed via an environment variable to docker-compose.yml build: args:
+ARG SQ1_UID=1000
+
+# Add the sq1 user
+RUN useradd -u ${SQ1_UID} sq1
+
+# Add www-data to sq1's group
+RUN usermod -a -G sq1 www-data
+
+# Copy pool customizations to make the www pool run as the sq1 user
+COPY overrides.conf /etc/php/7.4/fpm/pool.d/z-overrides.conf
+
 # Install selected extensions and other stuff
 RUN apt-get update \
     && apt-get -y --no-install-recommends install \

--- a/php/7.4/Dockerfile
+++ b/php/7.4/Dockerfile
@@ -3,18 +3,6 @@ FROM phpdockerio/php74-fpm:latest
 # Fix debconf warnings upon build
 ARG DEBIAN_FRONTEND=noninteractive
 
-# Passed via an environment variable to docker-compose.yml build: args:
-ARG SQ1_UID=1000
-
-# Add the sq1 user
-RUN useradd -u ${SQ1_UID} sq1
-
-# Add www-data to sq1's group
-RUN usermod -a -G sq1 www-data
-
-# Copy pool customizations to make the www pool run as the sq1 user
-COPY overrides.conf /etc/php/7.4/fpm/pool.d/z-overrides.conf
-
 # Install selected extensions and other stuff
 RUN apt-get update \
     && apt-get -y --no-install-recommends install \
@@ -46,5 +34,19 @@ RUN echo "installing WP-CLI" \
     && curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar \
     && chmod +x wp-cli.phar \
     && mv wp-cli.phar /usr/local/bin/wp
+
+# Copy pool customizations to make the www pool run as the squareone user
+COPY overrides.conf /etc/php/7.4/fpm/pool.d/zzz-overrides.conf
+
+COPY docker-entrypoint.sh /
+ADD /docker-entrypoint.d/ /docker-entrypoint.d/
+ONBUILD ADD /docker-entrypoint.d/ /docker-entrypoint.d/
+
+RUN chmod +x /docker-entrypoint.sh
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+
+# Run the original DockerFile's cmd to start php-fpm
+CMD /usr/bin/php-fpm
 
 WORKDIR "/application"

--- a/php/7.4/docker-entrypoint.d/01permissions
+++ b/php/7.4/docker-entrypoint.d/01permissions
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+USER=squareone
+USER_ID=${SQ1_UID:-1000}
+GROUP_ID=${SQ1_GID:-1000}
+
+# Returns 1 if the user doesn't exist
+USER_EXISTS=$(id -u $USER > /dev/null 2>&1; echo $?)
+
+# user doesn't exist
+if [ "$USER_EXISTS" == "1" ]; then
+  groupadd -g "$GROUP_ID" "$USER"
+  useradd -u "$USER_ID" "$USER" -g "$GROUP_ID"
+  usermod -a -G "$USER" www-data
+fi
+
+exec "$@"

--- a/php/7.4/docker-entrypoint.sh
+++ b/php/7.4/docker-entrypoint.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+SCRIPT_DIR=/docker-entrypoint.d
+
+if [ -d "$SCRIPT_DIR" ]; then
+  /bin/run-parts --verbose "$SCRIPT_DIR"
+fi
+
+exec "$@"

--- a/php/7.4/overrides.conf
+++ b/php/7.4/overrides.conf
@@ -1,0 +1,31 @@
+[global]
+; Override default pid file
+pid = /run/php-fpm.pid
+
+; Avoid logs being sent to syslog
+error_log = /proc/self/fd/2
+
+; Set this to php default's max_execution_time to allow children to stop gracefully when fpm is commanded to stop
+; This helps avoiding 502's
+process_control_timeout = 30
+
+; Do not daemonize (eg send process to the background)
+daemonize = no
+
+[www]
+; a custom user that matches the host's user ID and created in the Dockerfile
+user = sq1
+group = sq1
+
+; Access from webserver container is via network, not socket file
+listen = [::]:9000
+
+; Redirect logs to stdout - FPM closes /dev/std* on startup
+access.log = /proc/self/fd/2
+catch_workers_output = yes
+
+; Remove "pool www" decoration from log output (older phpdocker.io containers for php use sed for this)
+decorate_workers_output = no
+
+; Required to allow config-by-environment
+clear_env = no

--- a/php/7.4/overrides.conf
+++ b/php/7.4/overrides.conf
@@ -1,31 +1,4 @@
-[global]
-; Override default pid file
-pid = /run/php-fpm.pid
-
-; Avoid logs being sent to syslog
-error_log = /proc/self/fd/2
-
-; Set this to php default's max_execution_time to allow children to stop gracefully when fpm is commanded to stop
-; This helps avoiding 502's
-process_control_timeout = 30
-
-; Do not daemonize (eg send process to the background)
-daemonize = no
-
 [www]
 ; a custom user that matches the host's user ID and created in the Dockerfile
-user = sq1
-group = sq1
-
-; Access from webserver container is via network, not socket file
-listen = [::]:9000
-
-; Redirect logs to stdout - FPM closes /dev/std* on startup
-access.log = /proc/self/fd/2
-catch_workers_output = yes
-
-; Remove "pool www" decoration from log output (older phpdocker.io containers for php use sed for this)
-decorate_workers_output = no
-
-; Required to allow config-by-environment
-clear_env = no
+user = squareone
+group = squareone


### PR DESCRIPTION
Reference: https://github.com/moderntribe/square-one/pull/492

A corresponding PR to square one will come for docker-compose.yml