### PR TITLE
Remove hirak/prestissimo 

### DIFF
--- a/php/7.2/Dockerfile
+++ b/php/7.2/Dockerfile
@@ -57,8 +57,6 @@ RUN apt-get update \
        zip \
        zlib \
     && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
-    && composer global require hirak/prestissimo \
-    && composer clear-cache \
     && apt-get clean; rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/* ~/.composer
 
 

--- a/php/7.3/Dockerfile
+++ b/php/7.3/Dockerfile
@@ -57,8 +57,6 @@ RUN apt-get update \
        zip \
        zlib \
     && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
-    && composer global require hirak/prestissimo \
-    && composer clear-cache \
     && apt-get clean; rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/* ~/.composer
 
 

--- a/php/7.4/Dockerfile
+++ b/php/7.4/Dockerfile
@@ -57,8 +57,6 @@ RUN apt-get update \
        zip \
        zlib \
     && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
-    && composer global require hirak/prestissimo \
-    && composer clear-cache \
     && apt-get clean; rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/* ~/.composer
 
 


### PR DESCRIPTION
which just gets overwritten on volume map. `so` global will install it into the container at a later date.