### PR TITLE
Explicitly install composer v1

### DIFF
--- a/php/7.2/Dockerfile
+++ b/php/7.2/Dockerfile
@@ -56,7 +56,7 @@ RUN apt-get update \
        yaml \
        zip \
        zlib \
-    && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
+    && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer --1 \
     && apt-get clean; rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/* ~/.composer
 
 

--- a/php/7.3/Dockerfile
+++ b/php/7.3/Dockerfile
@@ -56,7 +56,7 @@ RUN apt-get update \
        yaml \
        zip \
        zlib \
-    && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
+    && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer --1 \
     && apt-get clean; rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/* ~/.composer
 
 

--- a/php/7.4/Dockerfile
+++ b/php/7.4/Dockerfile
@@ -56,7 +56,7 @@ RUN apt-get update \
        yaml \
        zip \
        zlib \
-    && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
+    && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer --1 \
     && apt-get clean; rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/* ~/.composer
 
 
@@ -80,9 +80,6 @@ USER "$PHP_USER:$PHP_USER"
 
 COPY docker-entrypoint /usr/local/bin/
 COPY docker-entrypoint.d /docker-entrypoint.d/
-
-# Copy pool customizations to make the www pool run as the squareone user
-#COPY overrides.conf /usr/local/etc/php-fpm.d/zz-overrides.conf
 
 ENTRYPOINT ["docker-entrypoint"]
 


### PR DESCRIPTION
Apparently not documented, I found this and it works: https://github.com/composer/getcomposer.org/blob/master/web/installer#L652

```
[justin@host php]$ curl -sS https://getcomposer.org/installer | php -- --install-dir=/home/user --filename=composerv1 --1
All settings correct for using Composer
Downloading...

Composer (version 1.10.17) successfully installed to: /home/user/composerv1
Use it: php /home/user/composerv1

[justin@host php]$ /home/user/composerv1 --version
Composer version 1.10.17 2020-10-30 22:31:58
```