### PR TITLE
Add php8.0 docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ Image Name: `moderntribe/squareone-php`
 
 ### Supported Tags
 
-* `latest`: The latest Dockerfile version using the most recent PHP version (currently 7.4),
+* `latest`: The latest Dockerfile version using the most recent PHP version (currently 8.0),
   built from the `master` branch.
-* `74-latest`: The latest Dockerfile version for PHP 7.4, built from the `master` branch.
-* `74-<x.y.z>`: Specific Dockerfile versions for PHP 7.4, built based on matching tags.
+* `80-latest`: The latest Dockerfile version for PHP 8.0, built from the `master` branch.
+* `80-<x.y.z>` or `80-<x.y>`: Specific Dockerfile versions for PHP 8.0, built based on matching tags.
 
 ### Adding New Versions
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SquareOne Docker Images
 
-Base docker images for SquareOne projects
+Base docker images for SquareOne projects. [View it on DockerHub](https://hub.docker.com/r/moderntribe/squareone-php).
 
 ## PHP
 
@@ -12,10 +12,14 @@ Image Name: `moderntribe/squareone-php`
   built from the `master` branch.
 * `80-latest`: The latest Dockerfile version for PHP 8.0, built from the `master` branch.
 * `80-<x.y.z>` or `80-<x.y>`: Specific Dockerfile versions for PHP 8.0, built based on matching tags.
+* `74-latest`: The latest Dockerfile version for PHP 7.4, built from the `master` branch.
+* `74-<x.y.z>` or `74-<x.y>`: Specific Dockerfile versions for PHP 7.4, built based on matching tags.
+* We recommend you use the minor version, so you can continue to receive updates when doing a docker pull, 
+e.g. `moderntribe/squareone-php:80-1.0` `moderntribe/squareone-php:74-2.1`
 
 ### Adding New Versions
 
-* Create a directory for the new version, e.g., `/php/8.0/`
+* Create a directory for the new version, e.g., `/php/8.1/`
 * Create the Dockerfile and any supporting files in that directory.
 * Add automated build configurations to Docker Hub `moderntribe/squareone-php` for the PHP version. Here is an
   example of the build rules to create version 8.0:

--- a/php/8.0/Dockerfile
+++ b/php/8.0/Dockerfile
@@ -1,0 +1,86 @@
+FROM php:8.0.0-fpm
+
+# Fix debconf warnings upon build
+ARG DEBIAN_FRONTEND=noninteractive
+
+# PHP extension installation helper. See https://github.com/mlocati/docker-php-extension-installer
+COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/bin/
+
+# Install selected extensions and other stuff
+RUN apt-get update \
+    && apt-get -y --no-install-recommends install \
+       default-mysql-client \
+       git \
+       gosu \
+       less \
+       libsodium-dev \
+       msmtp \
+       procps \
+       unzip \
+       wget \
+       zip \
+    && install-php-extensions \
+       apcu \
+       bcmath \
+       bz2 \
+       curl \
+       dom \
+       exif \
+       fileinfo \
+       filter \
+       gd \
+       hash \
+       iconv \
+       igbinary \
+       imagick \
+       imap \
+       intl \
+       json \
+       mbstring \
+       mcrypt \
+       memcached \
+       mysqli \
+       opcache \
+       openssl \
+       pcntl \
+       pcre \
+       pdo_mysql \
+       readline \
+       redis \
+       simplexml \
+       soap \
+       sodium \
+       xdebug \
+       xml \
+       xmlreader \
+       yaml \
+       zip \
+       zlib \
+    && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer --1 \
+    && apt-get clean; rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/* ~/.composer
+
+
+# Install fixuid to set the PHP-FPM user
+ARG PHP_USER=squareone
+RUN addgroup --gid 1000 "$PHP_USER" \
+    && adduser --uid 1000 --ingroup "$PHP_USER" --home "/home/$PHP_USER" --shell /bin/bash --disabled-password --gecos "" "$PHP_USER" \
+    && curl -SsL https://github.com/boxboat/fixuid/releases/download/v0.5/fixuid-0.5-linux-amd64.tar.gz | tar -C /usr/local/bin -xzf - \
+    && chown root:root /usr/local/bin/fixuid \
+    && chmod 4755 /usr/local/bin/fixuid \
+    && mkdir -p /etc/fixuid \
+    && printf "user: $PHP_USER\ngroup: $PHP_USER\n" > /etc/fixuid/config.yml
+
+# WP CLI
+RUN echo "installing WP-CLI" \
+    && curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar \
+    && chmod +x wp-cli.phar \
+    && mv wp-cli.phar /usr/local/bin/wp
+
+USER "$PHP_USER:$PHP_USER"
+
+COPY docker-entrypoint /usr/local/bin/
+COPY docker-entrypoint.d /docker-entrypoint.d/
+
+ENTRYPOINT ["docker-entrypoint"]
+
+WORKDIR "/application"

--- a/php/8.0/Dockerfile
+++ b/php/8.0/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.0.0-fpm
+FROM php:8.0-fpm
 
 # Fix debconf warnings upon build
 ARG DEBIAN_FRONTEND=noninteractive
@@ -49,6 +49,7 @@ RUN apt-get update \
        redis \
        simplexml \
        soap \
+       sockets \
        sodium \
        xdebug \
        xml \

--- a/php/8.0/docker-entrypoint
+++ b/php/8.0/docker-entrypoint
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+SCRIPT_DIR=/docker-entrypoint.d
+
+if [ -d "$SCRIPT_DIR" ]; then
+  /bin/run-parts --verbose "$SCRIPT_DIR"
+fi
+
+set -- php-fpm "$@"
+
+exec "$@"

--- a/php/8.0/docker-entrypoint.d/01-permissions
+++ b/php/8.0/docker-entrypoint.d/01-permissions
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+eval $( fixuid )

--- a/php/8.0/overrides.conf
+++ b/php/8.0/overrides.conf
@@ -1,0 +1,4 @@
+[www]
+; a custom user that matches the host's user ID and created in the Dockerfile
+user = squareone
+group = squareone


### PR DESCRIPTION
Edit: The image built this time around, looks like the Imagick issue is fixed.

Waiting on Imagick support: https://github.com/mlocati/docker-php-extension-installer#supported-php-extensions

https://github.com/Imagick/imagick/issues/358

