### PR TITLE
Add xml-rpc to the 7.4 image

### DIFF
--- a/php/7.4/Dockerfile
+++ b/php/7.4/Dockerfile
@@ -54,6 +54,7 @@ RUN apt-get update \
        xdebug \
        xml \
        xmlreader \
+       xmlrpc \
        yaml \
        zip \
        zlib \


### PR DESCRIPTION
Tested locally, builds properly and xmlrpc is available with `php -i`