### PR TITLE
Feature/php8.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ e.g. `moderntribe/squareone-php:80-1.0` `moderntribe/squareone-php:74-2.1`
 
 After you've made changes to a Dockerfile, it should be built locally and tested **before** being released.
 
+* Update the php extension installer image: `docker pull mlocati/php-extension-installer`
 * cd into the folder of the `Dockerfile` that was modified
 * Build and tag the image with a custom name: `docker build -t moderntribe/squareone-php:$version-test .`, e.g. `docker build -t moderntribe/squareone-php:74-3.0.6-test .`
 * Test it in the [square-one framework](https://github.com/moderntribe/square-one) by temporarily editing [dev/docker/docker-compose.yml](https://github.com/moderntribe/square-one/blob/main/dev/docker/docker-compose.yml#L30) and updating the `x-php` image.

--- a/php/8.1/Dockerfile
+++ b/php/8.1/Dockerfile
@@ -1,0 +1,91 @@
+FROM php:8.1-fpm
+
+# Fix debconf warnings upon build
+ARG DEBIAN_FRONTEND=noninteractive
+
+# PHP extension installation helper. See https://github.com/mlocati/docker-php-extension-installer
+COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/bin/
+
+# Install selected extensions and other stuff
+RUN apt-get update \
+    && apt-get -y --no-install-recommends install \
+       libavif-dev \
+       default-mysql-client \
+       git \
+       gosu \
+       less \
+       libsodium-dev \
+       msmtp \
+       procps \
+       unzip \
+       wget \
+       zip \
+    && install-php-extensions \
+       @composer \
+       apcu \
+       bcmath \
+       bz2 \
+       curl \
+       dom \
+       ds \
+       exif \
+       fileinfo \
+       filter \
+       gd \
+       hash \
+       iconv \
+       igbinary \
+       imagick \
+       imap \
+       intl \
+       json \
+       ldap \
+       mbstring \
+       mcrypt \
+       memcached \
+       mysqli \
+       opcache \
+       openssl \
+       pcntl \
+       pcre \
+       pdo_mysql \
+       readline \
+       redis \
+       simplexml \
+       soap \
+       sockets \
+       sodium \
+       xdebug \
+       xml \
+       xmlreader \
+       xmlrpc \
+       yaml \
+       zip \
+       zlib \
+    && apt-get clean; rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/* ~/.composer
+
+
+# Install fixuid to set the PHP-FPM user
+ARG PHP_USER=squareone
+RUN addgroup --gid 1000 "$PHP_USER" \
+    && adduser --uid 1000 --ingroup "$PHP_USER" --home "/home/$PHP_USER" --shell /bin/bash --disabled-password --gecos "" "$PHP_USER" \
+    && curl -SsL https://github.com/boxboat/fixuid/releases/download/v0.5.1/fixuid-0.5.1-linux-amd64.tar.gz | tar -C /usr/local/bin -xzf - \
+    && chown root:root /usr/local/bin/fixuid \
+    && chmod 4755 /usr/local/bin/fixuid \
+    && mkdir -p /etc/fixuid \
+    && printf "user: $PHP_USER\ngroup: $PHP_USER\n" > /etc/fixuid/config.yml
+
+# WP CLI
+RUN echo "installing WP-CLI" \
+    && curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar \
+    && chmod +x wp-cli.phar \
+    && mv wp-cli.phar /usr/local/bin/wp
+
+USER "$PHP_USER:$PHP_USER"
+
+COPY docker-entrypoint /usr/local/bin/
+COPY docker-entrypoint.d /docker-entrypoint.d/
+
+ENTRYPOINT ["docker-entrypoint"]
+
+WORKDIR "/application"

--- a/php/8.1/docker-entrypoint
+++ b/php/8.1/docker-entrypoint
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+SCRIPT_DIR=/docker-entrypoint.d
+
+if [ -d "$SCRIPT_DIR" ]; then
+  /bin/run-parts --verbose "$SCRIPT_DIR"
+fi
+
+set -- php-fpm "$@"
+
+exec "$@"

--- a/php/8.1/docker-entrypoint.d/01-permissions
+++ b/php/8.1/docker-entrypoint.d/01-permissions
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+eval $( fixuid )

--- a/php/8.1/overrides.conf
+++ b/php/8.1/overrides.conf
@@ -1,0 +1,4 @@
+[www]
+; a custom user that matches the host's user ID and created in the Dockerfile
+user = squareone
+group = squareone


### PR DESCRIPTION
- Adds a PHP8.1 image, with `libavif-dev` to support [AVIF](https://php.watch/versions/8.1/gd-avif).
- Installs composer via extension instead of manually.
- Updates README to refresh local image cache when build testing.