### PR TITLE
Add php-8.2 docker image

### DIFF
--- a/php/8.2/Dockerfile
+++ b/php/8.2/Dockerfile
@@ -1,0 +1,91 @@
+FROM php:8.2-fpm
+
+# Fix debconf warnings upon build
+ARG DEBIAN_FRONTEND=noninteractive
+
+# PHP extension installation helper. See https://github.com/mlocati/docker-php-extension-installer
+COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/bin/
+
+# Install selected extensions and other stuff
+RUN apt-get update \
+    && apt-get -y --no-install-recommends install \
+       libavif-dev \
+       default-mysql-client \
+       git \
+       gosu \
+       less \
+       libsodium-dev \
+       msmtp \
+       procps \
+       unzip \
+       wget \
+       zip \
+    && install-php-extensions \
+       @composer \
+       apcu \
+       bcmath \
+       bz2 \
+       curl \
+       dom \
+       ds \
+       exif \
+       fileinfo \
+       filter \
+       gd \
+       hash \
+       iconv \
+       igbinary \
+       imagick \
+       imap \
+       intl \
+       json \
+       ldap \
+       mbstring \
+       mcrypt \
+       memcached \
+       mysqli \
+       opcache \
+       openssl \
+       pcntl \
+       pcre \
+       pdo_mysql \
+       readline \
+       redis \
+       simplexml \
+       soap \
+       sockets \
+       sodium \
+       xdebug \
+       xml \
+       xmlreader \
+       xmlrpc \
+       yaml \
+       zip \
+       zlib \
+    && apt-get clean; rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/* ~/.composer
+
+
+# Install fixuid to set the PHP-FPM user
+ARG PHP_USER=squareone
+RUN addgroup --gid 1000 "$PHP_USER" \
+    && adduser --uid 1000 --ingroup "$PHP_USER" --home "/home/$PHP_USER" --shell /bin/bash --disabled-password --gecos "" "$PHP_USER" \
+    && curl -SsL https://github.com/boxboat/fixuid/releases/download/v0.6.0/fixuid-0.6.0-linux-amd64.tar.gz | tar -C /usr/local/bin -xzf - \
+    && chown root:root /usr/local/bin/fixuid \
+    && chmod 4755 /usr/local/bin/fixuid \
+    && mkdir -p /etc/fixuid \
+    && printf "user: $PHP_USER\ngroup: $PHP_USER\n" > /etc/fixuid/config.yml
+
+# WP CLI
+RUN echo "installing WP-CLI" \
+    && curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar \
+    && chmod +x wp-cli.phar \
+    && mv wp-cli.phar /usr/local/bin/wp
+
+USER "$PHP_USER:$PHP_USER"
+
+COPY docker-entrypoint /usr/local/bin/
+COPY docker-entrypoint.d /docker-entrypoint.d/
+
+ENTRYPOINT ["docker-entrypoint"]
+
+WORKDIR "/application"

--- a/php/8.2/docker-entrypoint
+++ b/php/8.2/docker-entrypoint
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+SCRIPT_DIR=/docker-entrypoint.d
+
+if [ -d "$SCRIPT_DIR" ]; then
+  /bin/run-parts --verbose "$SCRIPT_DIR"
+fi
+
+set -- php-fpm "$@"
+
+exec "$@"

--- a/php/8.2/docker-entrypoint.d/01-permissions
+++ b/php/8.2/docker-entrypoint.d/01-permissions
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+eval $( fixuid )

--- a/php/8.2/overrides.conf
+++ b/php/8.2/overrides.conf
@@ -1,0 +1,4 @@
+[www]
+; a custom user that matches the host's user ID and created in the Dockerfile
+user = squareone
+group = squareone


### PR DESCRIPTION
Add PHP 8.2 image.

There are many deprecated notices for WordPress, so for SquareOne, you'd need to ensure you have these in your `local-config.php`:

```php
define( 'WHOOPS_ENABLE', false );
define( 'WP_DEBUG_DISPLAY', false );
```

![image](https://github.com/moderntribe/squareone-docker-images/assets/1066195/b9a089eb-bd0a-47e2-916a-1a2ce80d1ed0)
